### PR TITLE
fix: base64encode warning

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -730,9 +730,7 @@ export const capitalize = (str: string): string => {
     return str.charAt(0).toUpperCase() + str.substring(1);
 };
 
-export const base64Encode = (str: string): string => {
-    return window.btoa(unescape(encodeURIComponent(str)));
-};
+export const base64Encode = (str: string): string => new TextEncoder().encode(str).toBase64();
 
 const npEscapes = new Map<string, string>();
 for (const [start, end] of [


### PR DESCRIPTION
Modern approach to this is to use TextEncoder, unicode will be damned

tested it with a script just to be sure
<img width="225" height="166" alt="image" src="https://github.com/user-attachments/assets/89482eae-2556-4582-a8c6-6d24f1ee29fb" />
