### PR TITLE
fix(ui): menubar sub trigger disabled look wasn't applied

### DIFF
--- a/src/lib/components/ui/menubar/menubar-sub-trigger.svelte
+++ b/src/lib/components/ui/menubar/menubar-sub-trigger.svelte
@@ -19,7 +19,7 @@
     data-slot="menubar-sub-trigger"
     data-inset={inset}
     class={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:ps-8",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:ps-8 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className
     )}
     {...restProps}


### PR DESCRIPTION
Fixes the disabled styling of `MenubarSubTrigger` to match `MenubarItem`. Disabled submenu triggers now correctly appear muted and ignore pointer events, providing consistent visual feedback and behavior across menubar components.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img width="432" alt="Before" src="https://github.com/user-attachments/assets/bc1f0726-4476-4f4e-981c-0c8504996cd0" />
    </td>
    <td>
      <img width="385" alt="After" src="https://github.com/user-attachments/assets/6c2f4808-ab03-4e45-9ce0-53a0e485cded" />
    </td>
  </tr>
</table>